### PR TITLE
fix: scope the code analysis for the secure build and push

### DIFF
--- a/src/jobs/build_and_push_server_to_aws_ecr.yml
+++ b/src/jobs/build_and_push_server_to_aws_ecr.yml
@@ -116,6 +116,7 @@ steps:
             source: <<parameters.build_dir>>
         - security/analyze_code:
             full_scan: true
+            root_dir: <<parameters.build_dir>>
         - security/scan_dependencies:
             pkg_json_dir: <<parameters.build_dir>>
         - security/scan_dockerfile:


### PR DESCRIPTION
Previously this was not possible due to limitation in the security orb. The latest version addressed the issue and now `analyze_code` step is scoped to the build dir.